### PR TITLE
Add `repository` url to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/tkh44/smitty.git"
   },
   "keywords": [],
   "babel": {


### PR DESCRIPTION
Hi there! Thanks for making this cool little library 🎉 

The `url` field inside `repository` was missing, which meant that the project's repo didn't show up on its npm page (I had to search separately to find the GitHub repo for the project). I just copy + pasted the project's git url in there to fix that.