### PR TITLE
V2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@
 /es
 /node_modules
 /umd
+/es
 npm-debug.log
 .idea

--- a/README.md
+++ b/README.md
@@ -304,8 +304,8 @@ console.log(store.state.foo) // logs 17
 console.log(historyReducer.history.state)
 // logs
 // [
-//   { state: { foo: 10 }, e: { foo: 5 }, type: 'foo/ADD' },
-//   { state: { foo: 17 }, e: { foo: 7 }, type: 'foo/ADD' }
+mitt
+mitt
 // ]
 
 ```

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -53,8 +53,7 @@ const Camera = connect(state => ({
     canvas = null;
 
     componentDidMount () {
-      const action = this.context.store.actions.startMediaStream('test')
-      action()
+      this.context.store.actions.startMediaStream('test')
     }
 
     render ({ streamError }) {

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -187,6 +187,14 @@ function Image ({ image, last }) {
   )
 }
 
+function GithubRibbon () {
+  return (
+    <iframe src="https://ghbtns.com/github-btn.html?user=tkh44&repo=smitty&type=star&count=true&size=large"
+            frameborder="0" scrolling="0" width="160px" height="30px"
+            style={{ marginLeft: 'auto' }}></iframe>
+  )
+}
+
 const App = connect(state => state)(props => (
   <div style={{ display: 'flex' }}>
     <Camera />
@@ -200,6 +208,15 @@ const App = connect(state => state)(props => (
         WebkitOverflowScrolling: 'touch'
       }}
     >
+      <div style={{
+        display: 'flex',
+        alignItems: 'center',
+        borderBottom: '1px solid #dee2e6'
+      }}>
+        <h2>Smitty Demo</h2>
+        <a href={'https://github.com/tkh44/smitty/tree/master/demo/src'} style={{ fontSize: '1rem', color: '#329af0', marginLeft: 8 }} target={'_blank'}>source</a>
+        <GithubRibbon />
+      </div>
       <ImageList />
     </div>
   </div>

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -215,7 +215,8 @@ const ImageList = connect(state => ({
     <div
       style={{
         display: 'flex',
-        flexFlow: 'wrap'
+        flexFlow: 'wrap',
+        perspective: '1000px'
       }}
     >
       {images.map((image, i) => {
@@ -267,6 +268,7 @@ function Image ({ image, index, onClick, selected }) {
   return (
     <a
       style={wrapperStyles}
+      class={selected ? 'animate-in' : ''}
       href={image.url}
       target={'_blank'}
       onClick={e => {

--- a/demo/src/App.js
+++ b/demo/src/App.js
@@ -214,6 +214,7 @@ function Image ({ image, index }) {
         order: index * -1
       }}
       href={image.url}
+      target={'_blank'}
     >
       <img src={image.url} style={{ width: '100%' }} />
     </a>

--- a/demo/src/style.css
+++ b/demo/src/style.css
@@ -8,3 +8,25 @@ body {
   color: #343a40;
   overflow: hidden;
 }
+
+.animate-in {
+  animation: up-in;
+  animation-duration: 250ms;
+  animation-fill-mode: forwards;
+  animation-timing-function: cubic-bezier(0.39, 0.04, 0.2, 1);
+  will-change: transform;
+  transform: translate3d(0, 0, -100px);
+  opacity: 0.5;
+}
+
+@keyframes up-in {
+  from {
+    transform: translate3d(0, 0, -100px);
+    opacity: 0.5;
+  }
+
+  to {
+    transform: translate3d(0, 0, 0);
+    opacity: 1;
+  }
+}

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,6 +1,6 @@
 module.exports = {
   type: 'react-component',
-  polyfill: false,
+  // polyfill: false,
   npm: {
     esModules: true,
     umd: {
@@ -12,7 +12,7 @@ module.exports = {
   },
   babel: {
     loose: true,
-    runtime: false
+    runtime: true
   },
   webpack: {
     uglify: {

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,9 +1,6 @@
 module.exports = {
   type: 'react-component',
   polyfill: false,
-  karma: {
-    browsers: ['Chrome']
-  },
   npm: {
     esModules: true,
     umd: {

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,11 +1,33 @@
 module.exports = {
   type: 'react-component',
+  polyfill: false,
   npm: {
     esModules: true,
     umd: {
       global: 'smitty',
       externals: {
         mitt: 'mitt'
+      }
+    }
+  },
+  babel: {
+    loose: true,
+    runtime: false
+  },
+  webpack: {
+    uglify: {
+      mangle: true,
+      compress: {
+        sequences: true,
+        dead_code: true,
+        conditionals: true,
+        comparisons: true,
+        booleans: true,
+        unused: true,
+        unsafe_proto: true,
+        if_return: true,
+        join_vars: true,
+        drop_console: true
       }
     }
   }

--- a/nwb.config.js
+++ b/nwb.config.js
@@ -1,6 +1,9 @@
 module.exports = {
   type: 'react-component',
   polyfill: false,
+  karma: {
+    browsers: ['Chrome']
+  },
   npm: {
     esModules: true,
     umd: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "smitty",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Tiny flux implementation built on mitt",
   "main": "lib/index.js",
   "module": "es/index.js",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "nwb": "0.15.x",
     "preact": "^7.2.0",
     "preact-smitty": "0.0.4",
+    "raw-loader": "^0.5.1",
     "react": "^16.0.0-alpha.5",
     "react-dom": "^16.0.0-alpha.5"
   },

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deploy": "npm run build && gh-pages -d demo/dist"
   },
   "peerDependencies": {
-    "mitt": "^1.1.0"
+    "events": "^1.1.0"
   },
   "devDependencies": {
     "gh-pages": "^0.12.0",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "gh-pages": "^0.12.0",
+    "localforage": "^1.5.0",
     "nwb": "0.15.x",
     "preact": "^7.2.0",
     "preact-smitty": "0.0.4",

--- a/src/index.js
+++ b/src/index.js
@@ -1,29 +1,37 @@
 import mitt from 'mitt'
 
-class Store {
-  constructor (initialState) {
-    this._state = initialState
-    this.actions = {}
-    this.events = mitt()
-    this.on = this.events.on
-    this.off = this.events.off
-    this.emit = this.emit.bind(this)
-    this.handleActions = this.handleActions.bind(this)
-  }
+function Store (initialState) {
+  let _state = initialState
+  this.actions = {}
+  this.events = mitt()
+  this.on = this.events.on
+  this.off = this.events.off
+  this.emit = this.emit.bind(this)
+  this.handleActions = this.handleActions.bind(this)
 
+  Object.defineProperty(this, 'state', {
+    get: function () {
+      return _state
+    },
+    set: function (value) {
+      _state = value
+    }
+  })
+}
+
+Object.assign(Store.prototype, {
   get state () {
     return this._state
-  }
+  },
 
   set state (nextState) {
     this._state = nextState
-  }
+  },
 
   emit (type, payload) {
-    console.log(type)
     if (typeof type === 'function') return type(this)
     this.events.emit(type, payload)
-  }
+  },
 
   createAction (type) {
     if (typeof type === 'function') {
@@ -33,13 +41,13 @@ class Store {
     const actionCreator = payload => this.emit(type, payload)
     actionCreator.toString = () => type.toString()
     return actionCreator
-  }
+  },
 
   createActions (actionMap) {
     for (let creatorName in actionMap) {
       this.actions[creatorName] = this.createAction(actionMap[creatorName])
     }
-  }
+  },
 
   handleActions (handlerMap) {
     for (let type in handlerMap) {
@@ -54,7 +62,9 @@ class Store {
       this.events.on(type, handler)
     }
   }
-}
+})
+
+
 
 export function createStore (initialState) {
   return new Store(initialState)

--- a/src/index.js
+++ b/src/index.js
@@ -42,11 +42,9 @@ Object.assign(Store.prototype, {
   handleActions (handlerMap) {
     for (let type in handlerMap) {
       let handler = (eventType, e) => {
-        if (eventType.substring(0, 6) === 'store:') return
-        const nextState = handlerMap[type](this.state, e, eventType) || this.state
-        if (this.state !== nextState) {
-          this.events.emit('store:state:change', this.state)
-        }
+        if (eventType.substring(0, 8) === '$$store:') return
+        this.state = handlerMap[type](this.state, e, eventType) || this.state
+        this.events.emit('$$store:state:change', this.state)
       }
       if (type !== '*') {
         handler = handler.bind(null, type)

--- a/src/index.js
+++ b/src/index.js
@@ -20,32 +20,22 @@ function Store (initialState) {
 }
 
 Object.assign(Store.prototype, {
-  get state () {
-    return this._state
-  },
-
-  set state (nextState) {
-    this._state = nextState
-  },
-
   emit (type, payload) {
     if (typeof type === 'function') return type(this)
     this.events.emit(type, payload)
   },
 
-  createAction (type) {
-    if (typeof type === 'function') {
-      return payload => this.emit(type(payload))
-    }
-
-    const actionCreator = payload => this.emit(type, payload)
-    actionCreator.toString = () => type.toString()
-    return actionCreator
-  },
-
   createActions (actionMap) {
     for (let creatorName in actionMap) {
-      this.actions[creatorName] = this.createAction(actionMap[creatorName])
+      const type = actionMap[creatorName]
+      let actionCreator
+      if (typeof type === 'function') {
+        actionCreator = payload => this.emit(type(payload))
+      } else {
+        actionCreator = payload => this.emit(type, payload)
+        actionCreator.toString = () => type.toString()
+      }
+      this.actions[creatorName] = actionCreator
     }
   },
 
@@ -63,8 +53,6 @@ Object.assign(Store.prototype, {
     }
   }
 })
-
-
 
 export function createStore (initialState) {
   return new Store(initialState)

--- a/src/index.js
+++ b/src/index.js
@@ -43,8 +43,10 @@ Object.assign(Store.prototype, {
     for (let type in handlerMap) {
       let handler = (eventType, e) => {
         if (eventType.substring(0, 6) === 'store:') return
-        this.state = handlerMap[type](this.state, e, eventType) || this.state
-        this.events.emit('store:change', this.state)
+        const nextState = handlerMap[type](this.state, e, eventType) || this.state
+        if (this.state !== nextState) {
+          this.events.emit('store:state:change', this.state)
+        }
       }
       if (type !== '*') {
         handler = handler.bind(null, type)

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -18,7 +18,7 @@ describe('smitty', () => {
 
   it('reducer is called with prev state and event data', done => {
     const store = createStore({ foo: 5 })
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e, type) => {
         expect(state.foo).toBe(5)
         expect(e).toEqual({ foo: 'bar' })
@@ -34,7 +34,7 @@ describe('smitty', () => {
 
   it('handles * event type', done => {
     const store = createStore({ foo: 5 })
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e, type) => {
         expect(state.foo).toBe(5)
         expect(e).toEqual({ foo: 5 })
@@ -55,7 +55,7 @@ describe('smitty', () => {
 
   it('no return from reducer is acceptable', done => {
     const store = createStore({ foo: 5 })
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e) => {
         state.foo += 5
       }
@@ -68,7 +68,7 @@ describe('smitty', () => {
 
   it('reducers are called in order with updated state', done => {
     const store = createStore({ foo: 5 })
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e) => {
         expect(state.foo).toBe(5)
         expect(e).toEqual({ foo: 'bar' })
@@ -76,7 +76,7 @@ describe('smitty', () => {
       }
     })
 
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e) => {
         expect(state.foo).toBe(6)
         expect(e).toEqual({ foo: 'bar' })
@@ -91,7 +91,7 @@ describe('smitty', () => {
 
   it('emit accepts a function argument and calls it with state and emit', done => {
     const store = createStore({ foo: 5 })
-    store.addReducer({
+    store.handleActions({
       'foo/ADD': (state, e) => {
         expect(state.foo).toBe(5)
         expect(e).toEqual(5)
@@ -118,7 +118,7 @@ describe('smitty', () => {
     class HistoryReducer {
       constructor (initialHistory = []) {
         this.history = createStore(initialHistory)
-        this.history.addReducer({
+        this.history.handleActions({
           update: (state, e) => {
             state.push(e)
           }
@@ -136,7 +136,7 @@ describe('smitty', () => {
     }
 
     const historyReducer = new HistoryReducer([])
-    store.addReducer(historyReducer)
+    store.handleActions(historyReducer)
 
     store.emit('foo/ADD', { foo: 5 })
     expect(store.state.foo).toBe(10)

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -12,7 +12,7 @@ describe('smitty', () => {
     expect(createStore({ foo: 5 }).state).toEqual({ foo: 5 })
   })
 
-  it('exposes the mitt api', () => {
+  it('exposes the events api', () => {
     expect(createStore()).toIncludeKeys(Object.keys(mitt()))
   })
 
@@ -126,7 +126,7 @@ describe('smitty', () => {
       }
 
       onUpdate (state, e, type) {
-        this.history.emit('update', { state, e, type })
+        this.history.emit('update', { state, events, type })
       }
     }
 
@@ -145,7 +145,7 @@ describe('smitty', () => {
         state: {
           foo: 10
         },
-        e: {
+        events: {
           foo: 5
         },
         type: 'foo/ADD'

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -174,7 +174,7 @@ describe('smitty', () => {
     store.actions.start()
   })
 
-  it('`store:change` event is fired after a state change', done => {
+  it('`$$store:state:change` event is fired after action handler is called', done => {
     const store = createStore({ foo: 5 })
 
     store.createActions({
@@ -191,7 +191,7 @@ describe('smitty', () => {
       }
     })
 
-    store.events.on('store:change', (state) => {
+    store.events.on('$$store:state:change', (state) => {
       expect(state.foo).toEqual(10)
       done()
     })


### PR DESCRIPTION
Major changes:

#### Action creators now receive ONE arguement, `store`.
This expands what is possible in an action handler

#### Renamed `addReducer` to `handleActions` (inspired by redux-actions)
The name no longer made sense. Returning a _new_ state from the handler is no longer required.

#### Added `createActions`  (inspired by redux-actions)

Allows developer to create actions and have them available directly from the store
```js
store.createActions({
  startMediaStream: (constraints) => async store => {
    try {
      const stream = await navigator.mediaDevices.getUserMedia(constraints)
      store.actions.mediaStreamSuccess(stream)
    } catch (err) {
      store.actions.mediaStreamError(err)
    }
  },
  addImage: 'camera/ADD_IMAGE'
})

// ...later
store.actions.startMediaStream()
store.actions.addImage({ audio: true, video: true })
```

If the property of the action creator is a plain string like `addImage: 'camera/ADD_IMAGE'` you can use the name in your reducer.

```js
store.handleActions({
  [store.actions.mediaStreamSuccess]: (state, stream) => {
    state.camera.stream = stream
  },
  [store.actions.mediaStreamError]: (state, error) => {
    state.camera.streamError = error
  },
  [store.actions.addImage]: (state, image) => {
    state.camera.images.push(image)
  }
})
```

#### Reserved event types with the prefix `$$store:`
`$$store:state:change` is fired after an action handler is called
 
